### PR TITLE
updated version to 2018.11.07

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.06" %}
+{% set version = "2018.11.07" %}
 
 package:
   name: regex
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/r/regex/regex-{{ version }}.tar.gz
-  sha256: 41b70db2608726396de185e7571a70391507ab47a64b564f59861ff13f2c50a5
+  sha256: 7bfb6e13ed8195513160550c3a82c49da8bbc6df5d149089cd37f51f36eddd39
 
 build:
   number: 1000


### PR DESCRIPTION
updated version fixes the issue with awesome-slugify:

https://github.com/conda-forge/awesome-slugify-feedstock/issues/10

It is set to build number 1000, because that what it was in the feedstock -- I image we want to reset that to 0

tested only with py2 on os-X, but not a big change...
