### PR TITLE
Add @xhochy as a maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,3 +35,4 @@ extra:
   recipe-maintainers:
     - kwilcox
     - ocefpaf
+    - xhochy


### PR DESCRIPTION
As I would like to bring conda-forge/spacy-feedstock#47 forward, I would need to rebuild an old version of `regex` with the new compiler. As a maintainer, this would be a lot simpler.